### PR TITLE
ノートの新規作成~ボタンの実装~

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import SideBar from './components/side_bar/SideBar'
 import { useEffect, useState } from 'react'
 import type{Note ,CopyNote} from './components/Features/Note'
 import { dummydate } from './components/Data/dummydate1'
-import { saveEvent } from './components/Features/Utils'
+import { saveEvent,createNewNote } from './components/Features/Utils'
 
 function App() {
   const [notes,setNotes] = useState<Note[]>(()=>{
@@ -21,9 +21,16 @@ function App() {
     } 
 
   //notesが変更された時に実行する（自動保存)
-  useEffect(() =>{
+  useEffect(() => {
     localStorage.setItem("notes",JSON.stringify(notes));
   },[notes])
+
+  //ノート新規作成ボタンが押された時のイベントハンドラ
+  const createHandler = () => {
+    const newNote = createNewNote()
+    setNotes([newNote,...notes]);//新しいノートを追加する
+    setEditNote(newNote);
+  }
 
   return (
       <BrowserRouter>
@@ -32,6 +39,7 @@ function App() {
               notes={notes}
               editNote={editNote}
               setEditNote={setEditNote}
+              createHandler={createHandler}
             />
         
           <div className="app-mainContents">

--- a/src/components/Features/Note.ts
+++ b/src/components/Features/Note.ts
@@ -18,7 +18,7 @@ export type CopyNote = Note | null;
 export type MainContentProps = {
     editNote : CopyNote;
     setEditNote : React.Dispatch<React.SetStateAction<CopyNote>>;
-    saveHandler: () =>void;
+    saveHandler: () => void;
 }
 
 //useState()を受け取り内容を変更する
@@ -26,4 +26,5 @@ export type NoteProps = {
     notes : Note[];
     editNote : CopyNote;
     setEditNote:React.Dispatch<React.SetStateAction<Note | null>>;
+    createHandler:() => void;
 }

--- a/src/components/Features/Utils.ts
+++ b/src/components/Features/Utils.ts
@@ -11,3 +11,16 @@ export function saveEvent(notes:Note[],editNote:Note){
     })
     return updateNotes
 }
+
+//新しいノートを作成する
+export function createNewNote(){
+    const newNote:Note = {
+        id : crypto.randomUUID(),
+        title : "",
+        content : "",
+        created : Date.now(),
+        updated : Date.now()
+    }
+    
+    return newNote
+}

--- a/src/components/side_bar/SideBar.tsx
+++ b/src/components/side_bar/SideBar.tsx
@@ -6,7 +6,7 @@ import { data } from 'react-router-dom';
 import MainFeature from '../main_contents/MainFeature';
 
 //サイドバーの描画をする
-function SideBar({notes,editNote,setEditNote}:NoteProps){
+function SideBar({notes,editNote,setEditNote,createHandler}:NoteProps){
     const [isOpen,setIsOpen] = useState(false);//サイドバーの状態
 
     return(
@@ -21,6 +21,7 @@ function SideBar({notes,editNote,setEditNote}:NoteProps){
                 <>
                     <button 
                     className='New-Note-Button'
+                    onClick={createHandler}
                     >
                         + ノート新規作成
                     </button>


### PR DESCRIPTION
## 変更点
ボタン押下時にイベントハンドラーを発火させ、新規作成したノートを setNotes（State）の先頭へ追加する処理を実装しました。

また、追加したノートを即座に setEditNote() で設定することで、作成後すぐに編集画面へ切り替わるよう変更を行いました。